### PR TITLE
Update Profile Image display functionality

### DIFF
--- a/resources/views/pages/profile/show.blade.php
+++ b/resources/views/pages/profile/show.blade.php
@@ -110,13 +110,13 @@ $(function() {
     axios.get(
         profileImgUri,
         {
-            baseURL: mediaWsUrl
+            baseURL: mediaWsUrl + 'faculty/media'
         }
     ).then(function(response) {
-        // Media WS results in a redirect when it returns the proper image
-        // so we can use that as the "src" attribute in the profile image
+        // Media WS results in a JSON object when it returns the proper image
+        // result so we can use that as the "src" attribute in the profile image
         // placeholder
-        $("#profile-image").attr('src', response.request.responseURL);
+        $("#profile-image").attr('src', response.data.avatar_image);
     }).catch(function(error) {
         console.error(error);
     });

--- a/resources/views/pages/search-results.blade.php
+++ b/resources/views/pages/search-results.blade.php
@@ -167,13 +167,13 @@ $(function() {
         axios.get(
             profileImgUri,
             {
-                baseURL: mediaWsUrl
+                baseURL: mediaWsUrl + 'faculty/media'
             }
         ).then(function(response) {
-            // Media WS results in a redirect when it returns the proper image
-            // so we can use that as the "src" attribute in the profile image
+            // Media WS results in a JSON object when it returns the proper image
+            // result so we can use that as the "src" attribute in the profile image
             // placeholder
-            $(element).attr('src', response.request.responseURL);
+            $(element).attr('src', response.data.avatar_image);
         }).catch(function(error) {
             console.error(error);
         });


### PR DESCRIPTION
Updated the Axios calls for profile images to reference the new structure of the Media API. This should prevent any future CORS issues for when the profile image is cached and retrieved from the filesystem instead of S3.

Make sure you switch the env value for `MEDIA_WEB_SERVICE` to use the `1.1` version, not the `1.0` version.