### PR TITLE
Debugging cors issue

### DIFF
--- a/resources/views/pages/profile/show.blade.php
+++ b/resources/views/pages/profile/show.blade.php
@@ -112,7 +112,7 @@ $(function() {
     axios.get(
         profileImgUri,
         {
-            baseURL: mediaWsUrl + 'faculty/media/'
+            baseURL: mediaWsUrl + 'faculty/media'
         }
     ).then(function(response) {
         $("#profile-image").attr('src',response.request.responseURL);

--- a/resources/views/pages/profile/show.blade.php
+++ b/resources/views/pages/profile/show.blade.php
@@ -106,19 +106,18 @@
 @section('page-specific-scripts')
 <script>
 $(function() {
+    console.log("foo")
     var mediaWsUrl = $("meta[name=media-url]").attr('content');
     var profileImgUri = $("meta[name=person-uri]").attr('content') +
-        '/avatar';
+        '/avatar?source=true ';
     axios.get(
         profileImgUri,
         {
-            baseURL: mediaWsUrl + 'faculty/media'
+            baseURL: mediaWsUrl + 'faculty/media/'
         }
     ).then(function(response) {
-        // Media WS results in a JSON object when it returns the proper image
-        // result so we can use that as the "src" attribute in the profile image
-        // placeholder
-        $("#profile-image").attr('src', response.data.avatar_image);
+        console.log(response.request.responseURL);
+        $("#profile-image").attr('src',response.request.responseURL);
     }).catch(function(error) {
         console.error(error);
     });

--- a/resources/views/pages/profile/show.blade.php
+++ b/resources/views/pages/profile/show.blade.php
@@ -106,7 +106,6 @@
 @section('page-specific-scripts')
 <script>
 $(function() {
-    console.log("foo")
     var mediaWsUrl = $("meta[name=media-url]").attr('content');
     var profileImgUri = $("meta[name=person-uri]").attr('content') +
         '/avatar?source=true ';
@@ -116,7 +115,6 @@ $(function() {
             baseURL: mediaWsUrl + 'faculty/media/'
         }
     ).then(function(response) {
-        console.log(response.request.responseURL);
         $("#profile-image").attr('src',response.request.responseURL);
     }).catch(function(error) {
         console.error(error);

--- a/resources/views/pages/search-results.blade.php
+++ b/resources/views/pages/search-results.blade.php
@@ -170,7 +170,6 @@ $(function() {
                 baseURL: mediaWsUrl + 'faculty/media'
             }
         ).then(function(response) {
-            console.log(response.request.responseURL);
             $(element).attr('src',response.request.responseURL);
         }).catch(function(error) {
             console.error(error);

--- a/resources/views/pages/search-results.blade.php
+++ b/resources/views/pages/search-results.blade.php
@@ -161,7 +161,7 @@ $(function() {
     // iterate over the card images to load the respective profile images
     $("img.profile-card__img").each(function(index, element) {
         let profileUri = $(element).attr('data-profile-uri');
-        let profileImgUri = profileUri + '/avatar';
+        let profileImgUri = profileUri + '/avatar?source=true';
 
         // fire off the Axios call to retrieve the image
         axios.get(
@@ -170,10 +170,8 @@ $(function() {
                 baseURL: mediaWsUrl + 'faculty/media'
             }
         ).then(function(response) {
-            // Media WS results in a JSON object when it returns the proper image
-            // result so we can use that as the "src" attribute in the profile image
-            // placeholder
-            $(element).attr('src', response.data.avatar_image);
+            console.log(response.request.responseURL);
+            $(element).attr('src',response.request.responseURL);
         }).catch(function(error) {
             console.error(error);
         });


### PR DESCRIPTION
Steve identified a CORS error which:
- appeared only in Brave browser
- only on some faculty images, including Steve's image (on profile-view page AND search-results page)

So, Steve did some digging and discovered that profile-manager does NOT produce the same CORS error in Brave browser. Profile-manager uses the `?source=true` flag on the call to media, while faculty-v3 was not using that. This PR updates faculty-v3 to use the `?source=true` flag on all calls to media. I tested yesterday with Lisa, and this fixed the CORS error. 

The only thing that I'm trippin about is that the faculty-v3 codebase ORIGINALLY used this redirect method, and it caused CORS issues, which is why we switched to the JSON method. But maybe something changed on the webservice since then??? 

Please note that this my ENV variable for media:
`MEDIA_WEB_SERVICE=https://api.metalab.csun.edu/media/1.1/`