### PR TITLE
Update interests sections

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -10807,6 +10807,10 @@ body {
   min-height: calc(100vh - 30rem);
 }
 
+.empty-state-msg {
+  color: #6c757d;
+}
+
 .past-courses-list {
   margin-bottom: 0;
 }

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -21190,7 +21190,7 @@ if (token) {
 /***/ (function(module, exports) {
 
 /*!
- * Font Awesome Free 5.4.1 by @fontawesome - https://fontawesome.com
+ * Font Awesome Free 5.4.0 by @fontawesome - https://fontawesome.com
  * License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)
  */
 (function () {
@@ -21512,7 +21512,7 @@ var icons = {
   "less": [640, 512, [], "f41d", "M612.7 219c0-20.5 3.2-32.6 3.2-54.6 0-34.2-12.6-45.2-40.5-45.2h-20.5v24.2h6.3c14.2 0 17.3 4.7 17.3 22.1 0 16.3-1.6 32.6-1.6 51.5 0 24.2 7.9 33.6 23.6 37.3v1.6c-15.8 3.7-23.6 13.1-23.6 37.3 0 18.9 1.6 34.2 1.6 51.5 0 17.9-3.7 22.6-17.3 22.6v.5h-6.3V393h20.5c27.8 0 40.5-11 40.5-45.2 0-22.6-3.2-34.2-3.2-54.6 0-11 6.8-22.6 27.3-23.6v-27.3c-20.5-.7-27.3-12.3-27.3-23.3zm-105.6 32c-15.8-6.3-30.5-10-30.5-20.5 0-7.9 6.3-12.6 17.9-12.6s22.1 4.7 33.6 13.1l21-27.8c-13.1-10-31-20.5-55.2-20.5-35.7 0-59.9 20.5-59.9 49.4 0 25.7 22.6 38.9 41.5 46.2 16.3 6.3 32.1 11.6 32.1 22.1 0 7.9-6.3 13.1-20.5 13.1-13.1 0-26.3-5.3-40.5-16.3l-21 30.5c15.8 13.1 39.9 22.1 59.9 22.1 42 0 64.6-22.1 64.6-51s-22.5-41-43-47.8zm-358.9 59.4c-3.7 0-8.4-3.2-8.4-13.1V119.1H65.2c-28.4 0-41 11-41 45.2 0 22.6 3.2 35.2 3.2 54.6 0 11-6.8 22.6-27.3 23.6v27.3c20.5.5 27.3 12.1 27.3 23.1 0 19.4-3.2 31-3.2 53.6 0 34.2 12.6 45.2 40.5 45.2h20.5v-24.2h-6.3c-13.1 0-17.3-5.3-17.3-22.6s1.6-32.1 1.6-51.5c0-24.2-7.9-33.6-23.6-37.3v-1.6c15.8-3.7 23.6-13.1 23.6-37.3 0-18.9-1.6-34.2-1.6-51.5s3.7-22.1 17.3-22.1H93v150.8c0 32.1 11 53.1 43.1 53.1 10 0 17.9-1.6 23.6-3.7l-5.3-34.2c-3.1.8-4.6.8-6.2.8zM379.9 251c-16.3-6.3-31-10-31-20.5 0-7.9 6.3-12.6 17.9-12.6 11.6 0 22.1 4.7 33.6 13.1l21-27.8c-13.1-10-31-20.5-55.2-20.5-35.7 0-59.9 20.5-59.9 49.4 0 25.7 22.6 38.9 41.5 46.2 16.3 6.3 32.1 11.6 32.1 22.1 0 7.9-6.3 13.1-20.5 13.1-13.1 0-26.3-5.3-40.5-16.3l-20.5 30.5c15.8 13.1 39.9 22.1 59.9 22.1 42 0 64.6-22.1 64.6-51 .1-28.9-22.5-41-43-47.8zm-155-68.8c-38.4 0-75.1 32.1-74.1 82.5 0 52 34.2 82.5 79.3 82.5 18.9 0 39.9-6.8 56.2-17.9l-15.8-27.8c-11.6 6.8-22.6 10-34.2 10-21 0-37.3-10-41.5-34.2H290c.5-3.7 1.6-11 1.6-19.4.6-42.6-22.6-75.7-66.7-75.7zm-30 66.2c3.2-21 15.8-31 30.5-31 18.9 0 26.3 13.1 26.3 31h-56.8z"],
   "line": [448, 512, [], "f3c0", "M272.1 204.2v71.1c0 1.8-1.4 3.2-3.2 3.2h-11.4c-1.1 0-2.1-.6-2.6-1.3l-32.6-44v42.2c0 1.8-1.4 3.2-3.2 3.2h-11.4c-1.8 0-3.2-1.4-3.2-3.2v-71.1c0-1.8 1.4-3.2 3.2-3.2H219c1 0 2.1.5 2.6 1.4l32.6 44v-42.2c0-1.8 1.4-3.2 3.2-3.2h11.4c1.8-.1 3.3 1.4 3.3 3.1zm-82-3.2h-11.4c-1.8 0-3.2 1.4-3.2 3.2v71.1c0 1.8 1.4 3.2 3.2 3.2h11.4c1.8 0 3.2-1.4 3.2-3.2v-71.1c0-1.7-1.4-3.2-3.2-3.2zm-27.5 59.6h-31.1v-56.4c0-1.8-1.4-3.2-3.2-3.2h-11.4c-1.8 0-3.2 1.4-3.2 3.2v71.1c0 .9.3 1.6.9 2.2.6.5 1.3.9 2.2.9h45.7c1.8 0 3.2-1.4 3.2-3.2v-11.4c0-1.7-1.4-3.2-3.1-3.2zM332.1 201h-45.7c-1.7 0-3.2 1.4-3.2 3.2v71.1c0 1.7 1.4 3.2 3.2 3.2h45.7c1.8 0 3.2-1.4 3.2-3.2v-11.4c0-1.8-1.4-3.2-3.2-3.2H301v-12h31.1c1.8 0 3.2-1.4 3.2-3.2V234c0-1.8-1.4-3.2-3.2-3.2H301v-12h31.1c1.8 0 3.2-1.4 3.2-3.2v-11.4c-.1-1.7-1.5-3.2-3.2-3.2zM448 113.7V399c-.1 44.8-36.8 81.1-81.7 81H81c-44.8-.1-81.1-36.9-81-81.7V113c.1-44.8 36.9-81.1 81.7-81H367c44.8.1 81.1 36.8 81 81.7zm-61.6 122.6c0-73-73.2-132.4-163.1-132.4-89.9 0-163.1 59.4-163.1 132.4 0 65.4 58 120.2 136.4 130.6 19.1 4.1 16.9 11.1 12.6 36.8-.7 4.1-3.3 16.1 14.1 8.8 17.4-7.3 93.9-55.3 128.2-94.7 23.6-26 34.9-52.3 34.9-81.5z"],
   "linkedin": [448, 512, [], "f08c", "M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z"],
-  "linkedin-in": [448, 512, [], "f0e1", "M100.3 448H7.4V148.9h92.9V448zM53.8 108.1C24.1 108.1 0 83.5 0 53.8S24.1 0 53.8 0s53.8 24.1 53.8 53.8-24.1 54.3-53.8 54.3zM448 448h-92.7V302.4c0-34.7-.7-79.2-48.3-79.2-48.3 0-55.7 37.7-55.7 76.7V448h-92.8V148.9h89.1v40.8h1.3c12.4-23.5 42.7-48.3 87.9-48.3 94 0 111.3 61.9 111.3 142.3V448h-.1z"],
+  "linkedin-in": [448, 512, [], "f0e1", "M100.3 480H7.4V180.9h92.9V480zM53.8 140.1C24.1 140.1 0 115.5 0 85.8 0 56.1 24.1 32 53.8 32c29.7 0 53.8 24.1 53.8 53.8 0 29.7-24.1 54.3-53.8 54.3zM448 480h-92.7V334.4c0-34.7-.7-79.2-48.3-79.2-48.3 0-55.7 37.7-55.7 76.7V480h-92.8V180.9h89.1v40.8h1.3c12.4-23.5 42.7-48.3 87.9-48.3 94 0 111.3 61.9 111.3 142.3V480z"],
   "linode": [448, 512, [], "f2b8", "M437.4 226.3c-.3-.9-.9-1.4-1.4-2l-70-38.6c-.9-.6-2-.6-3.1 0l-58.9 36c-.9.6-1.4 1.7-1.4 2.6l-.9 31.4-24-16c-.9-.6-2.3-.6-3.1 0L240 260.9l-1.4-35.1c0-.9-.6-2-1.4-2.3l-36-24.3 33.7-17.4c1.1-.6 1.7-1.7 1.7-2.9l-5.7-132.3c0-.9-.9-2-1.7-2.6L138.6.3c-.9-.3-1.7-.3-2.3-.3L12.6 38.6c-1.4.6-2.3 2-2 3.7L38 175.4c.9 3.4 34 27.4 38.6 30.9l-26.9 12.9c-1.4.9-2 2.3-1.7 3.4l20.6 100.3c.6 2.9 23.7 23.1 27.1 26.3l-17.4 10.6c-.9.6-1.7 2-1.4 3.1 1.4 7.1 15.4 77.7 16.9 79.1l65.1 69.1c.6.6 1.4.6 2.3.9.6 0 1.1-.3 1.7-.6l83.7-66.9c.9-.6 1.1-1.4 1.1-2.3l-2-46 28 23.7c1.1.9 2.9.9 4 0l66.9-53.4c.9-.6 1.1-1.4 1.1-2.3l2.3-33.4 20.3 14c1.1.9 2.6.9 3.7 0l54.6-43.7c.6-.3 1.1-1.1 1.1-2 .9-6.5 10.3-70.8 9.7-72.8zm-204.8 4.8l4 92.6-90.6 61.2-14-96.6 100.6-57.2zm-7.7-180l5.4 126-106.6 55.4L104 97.7l120.9-46.6zM44 173.1L18 48l79.7 49.4 19.4 132.9L44 173.1zm30.6 147.8L55.7 230l70 58.3 13.7 93.4-64.8-60.8zm24.3 117.7l-13.7-67.1 61.7 60.9 9.7 67.4-57.7-61.2zm64.5 64.5l-10.6-70.9 85.7-61.4 3.1 70-78.2 62.3zm82-115.1c0-3.4.9-22.9-2-25.1l-24.3-20 22.3-14.9c2.3-1.7 1.1-5.7 1.1-8l29.4 22.6.6 68.3-27.1-22.9zm94.3-25.4l-60.9 48.6-.6-68.6 65.7-46.9-4.2 66.9zm27.7-25.7l-19.1-13.4 2-34c.3-.9-.3-2-1.1-2.6L308 259.7l.6-30 64.6 40.6-5.8 66.6zm54.6-39.8l-48.3 38.3 5.7-65.1 51.1-36.6-8.5 63.4z"],
   "linux": [448, 512, [], "f17c", "M196.1 123.6c-.2-1.4 1.9-2.3 3.2-2.9 1.7-.7 3.9-1 5.5-.1.4.2.8.7.6 1.1-.4 1.2-2.4 1-3.5 1.6-1 .5-1.8 1.7-3 1.7-1 .1-2.7-.4-2.8-1.4zm24.7-.3c1 .5 1.8 1.7 3 1.7 1.1 0 2.8-.4 2.9-1.5.2-1.4-1.9-2.3-3.2-2.9-1.7-.7-3.9-1-5.5-.1-.4.2-.8.7-.6 1.1.3 1.3 2.3 1.1 3.4 1.7zm214.7 310.2c-.5 8.2-6.5 13.8-13.9 18.3-14.9 9-37.3 15.8-50.9 32.2l-2.6-2.2 2.6 2.2c-14.2 16.9-31.7 26.6-48.3 27.9-16.5 1.3-32-6.3-40.3-23v-.1c-1.1-2.1-1.9-4.4-2.5-6.7-21.5 1.2-40.2-5.3-55.1-4.1-22 1.2-35.8 6.5-48.3 6.6-4.8 10.6-14.3 17.6-25.9 20.2-16 3.7-36.1 0-55.9-10.4l1.6-3-1.6 3c-18.5-9.8-42-8.9-59.3-12.5-8.7-1.8-16.3-5-20.1-12.3-3.7-7.3-3-17.3 2.2-31.7 1.7-5.1.4-12.7-.8-20.8-.6-3.9-1.2-7.9-1.2-11.8 0-4.3.7-8.5 2.8-12.4 4.5-8.5 11.8-12.1 18.5-14.5 6.7-2.4 12.8-4 17-8.3 5.2-5.5 10.1-14.4 16.6-20.2-2.6-17.2.2-35.4 6.2-53.3 12.6-37.9 39.2-74.2 58.1-96.7 16.1-22.9 20.8-41.3 22.5-64.7C158 103.4 132.4-.2 234.8 0c80.9.1 76.3 85.4 75.8 131.3-.3 30.1 16.3 50.5 33.4 72 15.2 18 35.1 44.3 46.5 74.4 9.3 24.6 12.9 51.8 3.7 79.1 1.4.5 2.8 1.2 4.1 2 1.4.8 2.7 1.8 4 2.9 6.6 5.6 8.7 14.3 10.5 22.4 1.9 8.1 3.6 15.7 7.2 19.7 11.1 12.4 15.9 21.5 15.5 29.7zM220.8 109.1c3.6.9 8.9 2.4 13 4.4-2.1-12.2 4.5-23.5 11.8-23 8.9.3 13.9 15.5 9.1 27.3-.8 1.9-2.8 3.4-3.9 4.6 6.7 2.3 11 4.1 12.6 4.9 7.9-9.5 10.8-26.2 4.3-40.4-9.8-21.4-34.2-21.8-44 .4-3.2 7.2-3.9 14.9-2.9 21.8zm-46.2 18.8c7.8-5.7 6.9-4.7 5.9-5.5-8-6.9-6.6-27.4 1.8-28.1 6.3-.5 10.8 10.7 9.6 19.6 3.1-2.1 6.7-3.6 10.2-4.6 1.7-19.3-9-33.5-19.1-33.5-18.9 0-24 37.5-8.4 52.1zm-9.4 20.9c1.5 4.9 6.1 10.5 14.7 15.3 7.8 4.6 12 11.5 20 15 2.6 1.1 5.7 1.9 9.6 2.1 18.4 1.1 27.1-11.3 38.2-14.9 11.7-3.7 20.1-11 22.7-18.1 3.2-8.5-2.1-14.7-10.5-18.2-11.3-4.9-16.3-5.2-22.6-9.3-10.3-6.6-18.8-8.9-25.9-8.9-14.4 0-23.2 9.8-27.9 14.2-.5.5-7.9 5.9-14.1 10.5-4.2 3.3-5.6 7.4-4.2 12.3zm-33.5 252.8L112.1 366c-6.8-9.2-13.8-14.8-21.9-16-7.7-1.2-12.6 1.4-17.7 6.9-4.8 5.1-8.8 12.3-14.3 18-7.8 6.5-9.3 6.2-19.6 9.9-6.3 2.2-11.3 4.6-14.8 11.3-2.7 5-2.1 12.2-.9 20 1.2 7.9 3 16.3.6 23.9v.2c-5 13.7-5 21.7-2.6 26.4 7.9 15.4 46.6 6.1 76.5 21.9 31.4 16.4 72.6 17.1 75.3-18 2.1-20.5-31.5-49-41-68.9zm153.9 35.8c3.2-11 6.3-21.3 6.8-29 .8-15.2 1.6-28.7 4.4-39.9 3.1-12.6 9.3-23.1 21.4-27.3 2.3-21.1 18.7-21.1 38.3-12.5 18.9 8.5 26 16 22.8 26.1 1 0 2-.1 4.2 0 5.2-16.9-14.3-28-30.7-34.8 2.9-12 2.4-24.1-.4-35.7-6-25.3-22.6-47.8-35.2-59-2.3-.1-2.1 1.9 2.6 6.5 11.6 10.7 37.1 49.2 23.3 84.9-3.9-1-7.6-1.5-10.9-1.4-5.3-29.1-17.5-53.2-23.6-64.6-11.5-21.4-29.5-65.3-37.2-95.7-4.5 6.4-12.4 11.9-22.3 15-4.7 1.5-9.7 5.5-15.9 9-13.9 8-30 8.8-42.4-1.2-4.5-3.6-8-7.6-12.6-10.3-1.6-.9-5.1-3.3-6.2-4.1-2 37.8-27.3 85.3-39.3 112.7-8.3 19.7-13.2 40.8-13.8 61.5-21.8-29.1-5.9-66.3 2.6-82.4 9.5-17.6 11-22.5 8.7-20.8-8.6 14-22 36.3-27.2 59.2-2.7 11.9-3.2 24 .3 35.2 3.5 11.2 11.1 21.5 24.6 29.9 0 0 24.8 14.3 38.3 32.5 7.4 10 9.7 18.7 7.4 24.9-2.5 6.7-9.6 8.9-16.7 8.9 4.8 6 10.3 13 14.4 19.6 37.6 25.7 82.2 15.7 114.3-7.2zM415 408.5c-10-11.3-7.2-33.1-17.1-41.6-6.9-6-13.6-5.4-22.6-5.1-7.7 8.8-25.8 19.6-38.4 16.3-11.5-2.9-18-16.3-18.8-29.5-.3.2-.7.3-1 .5-7.1 3.9-11.1 10.8-13.7 21.1-2.5 10.2-3.4 23.5-4.2 38.7-.7 11.8-6.2 26.4-9.9 40.6-3.5 13.2-5.8 25.2-1.1 36.3 7.2 14.5 19.5 20.4 33.7 19.3 14.2-1.1 30.4-9.8 43.6-25.5 22-26.6 62.3-29.7 63.2-46.5.3-5.1-3.1-13-13.7-24.6zM173.3 148.7c2 1.9 4.7 4.5 8 7.1 6.6 5.2 15.8 10.6 27.3 10.6 11.6 0 22.5-5.9 31.8-10.8 4.9-2.6 10.9-7 14.8-10.4 3.9-3.4 5.9-6.3 3.1-6.6-2.8-.3-2.6 2.6-6 5.1-4.4 3.2-9.7 7.4-13.9 9.8-7.4 4.2-19.5 10.2-29.9 10.2-10.4 0-18.7-4.8-24.9-9.7-3.1-2.5-5.7-5-7.7-6.9-1.5-1.4-1.9-4.6-4.3-4.9-1.4-.1-1.8 3.7 1.7 6.5z"],
   "lyft": [512, 512, [], "f3c3", "M0 81.1h77.8v208.7c0 33.1 15 52.8 27.2 61-12.7 11.1-51.2 20.9-80.2-2.8C7.8 334 0 310.7 0 289V81.1zm485.9 173.5v-22h23.8v-76.8h-26.1c-10.1-46.3-51.2-80.7-100.3-80.7-56.6 0-102.7 46-102.7 102.7V357c16 2.3 35.4-.3 51.7-14 17.1-14 24.8-37.2 24.8-59v-6.7h38.8v-76.8h-38.8v-23.3c0-34.6 52.2-34.6 52.2 0v77.1c0 56.6 46 102.7 102.7 102.7v-76.5c-14.5 0-26.1-11.7-26.1-25.9zm-294.3-99v113c0 15.4-23.8 15.4-23.8 0v-113H91v132.7c0 23.8 8 54 45 63.9 37 9.8 58.2-10.6 58.2-10.6-2.1 13.4-14.5 23.3-34.9 25.3-15.5 1.6-35.2-3.6-45-7.8v70.3c25.1 7.5 51.5 9.8 77.6 4.7 47.1-9.1 76.8-48.4 76.8-100.8V155.1h-77.1v.5z"],
@@ -23636,7 +23636,7 @@ function makeLayersCounterAbstract(params) {
 
 var noop$2 = function noop() {};
 var p = config.measurePerformance && PERFORMANCE && PERFORMANCE.mark && PERFORMANCE.measure ? PERFORMANCE : { mark: noop$2, measure: noop$2 };
-var preamble = 'FA "5.4.1"';
+var preamble = 'FA "5.4.0"';
 
 var begin = function begin(name) {
   p.mark(preamble + ' ' + name + ' begins');
@@ -28217,6 +28217,16 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
 //
 //
 //
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
 
 /* harmony default export */ __webpack_exports__["default"] = ({
     name: 'ProfileHome',
@@ -28544,16 +28554,16 @@ var render = function() {
                         ]
                       : _vm._e(),
                     _vm._v(" "),
-                    _vm.interests.length
-                      ? [
-                          _c(
-                            "div",
-                            { staticClass: "mb-3 pb-3 " },
-                            [
-                              _c("h6", { staticClass: "h5 mb-3" }, [
-                                _vm._v("INTERESTS")
-                              ]),
-                              _vm._v(" "),
+                    _c(
+                      "div",
+                      { staticClass: "mb-3 pb-3 " },
+                      [
+                        _c("h6", { staticClass: "h5 mb-3" }, [
+                          _vm._v("INTERESTS")
+                        ]),
+                        _vm._v(" "),
+                        _vm.interests.length
+                          ? [
                               _vm._l(_vm.interests, function(_interest) {
                                 return [
                                   _c(
@@ -28572,11 +28582,17 @@ var render = function() {
                                   )
                                 ]
                               })
-                            ],
-                            2
-                          )
-                        ]
-                      : _vm._e()
+                            ]
+                          : [
+                              _c("span", { staticClass: "empty-state-msg" }, [
+                                _vm._v(
+                                  "There are currently no interests to display."
+                                )
+                              ])
+                            ]
+                      ],
+                      2
+                    )
                   ],
                   2
                 ),
@@ -28764,38 +28780,42 @@ var render = function() {
                         ]
                       : _vm._e(),
                     _vm._v(" "),
-                    _vm.biography
-                      ? [
-                          _c(
-                            "h2",
-                            {
-                              staticClass: "h3 d-none d-md-block text-primary"
-                            },
-                            [_vm._v("Overview")]
-                          ),
-                          _vm._v(" "),
-                          _c(
-                            "h2",
-                            {
-                              staticClass:
-                                "h5 mb-3 d-block d-md-none text-uppercase"
-                            },
-                            [_vm._v("Overview")]
-                          ),
-                          _vm._v(" "),
-                          _c(
-                            "div",
-                            { staticClass: "mb-3 pb-3 mb-md-5 pb-md-4" },
-                            [
+                    _c(
+                      "h2",
+                      { staticClass: "h3 d-none d-md-block text-primary" },
+                      [_vm._v("Overview")]
+                    ),
+                    _vm._v(" "),
+                    _c(
+                      "h2",
+                      {
+                        staticClass: "h5 mb-3 d-block d-md-none text-uppercase"
+                      },
+                      [_vm._v("Overview")]
+                    ),
+                    _vm._v(" "),
+                    _c(
+                      "div",
+                      { staticClass: "mb-3 pb-3 mb-md-5 pb-md-4" },
+                      [
+                        _vm.biography
+                          ? [
                               _vm._v(
                                 "\n                            " +
                                   _vm._s(_vm.biography) +
                                   "\n                        "
                               )
                             ]
-                          )
-                        ]
-                      : _vm._e(),
+                          : [
+                              _c("span", { staticClass: "empty-state-msg" }, [
+                                _vm._v(
+                                  "There is currently no overview information to display."
+                                )
+                              ])
+                            ]
+                      ],
+                      2
+                    ),
                     _vm._v(" "),
                     _vm.badges.length
                       ? [
@@ -29304,6 +29324,11 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
 //
 //
 //
+//
+//
+//
+//
+//
 
 /* harmony default export */ __webpack_exports__["default"] = ({
     name: 'ProfileClasses',
@@ -29315,6 +29340,7 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
             selected_term: $("meta[name=current-term-id]").attr('content'),
             classes: [],
             office_hours: [],
+            teaching_interest: [],
             loading_all: true,
             loading_classes: false,
             loading_officehours: false
@@ -29339,6 +29365,9 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
         },
         current_term_id: function current_term_id() {
             return $("meta[name=current-term-id]").attr('content');
+        },
+        person_email: function person_email() {
+            return $("meta[name=person-email]").attr('content');
         }
     },
     methods: {
@@ -29385,6 +29414,14 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
                 }
             });
         },
+        loadTeachingInterests: function loadTeachingInterests() {
+            return axios.get('interests/academic?email=' + this.person_email, {
+                baseURL: $("meta[name=affinity-url]").attr('content'),
+                params: {
+                    email: this.person_email
+                }
+            });
+        },
         loadOfficeHours: function loadOfficeHours() {
             return axios.get('people/' + this.person_uri + '/office-hours', {
                 baseURL: this.api_url,
@@ -29409,7 +29446,7 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
 
         // make the Axios calls concurrently and wait for all of them to return
         // before applying the reactive data
-        axios.all([this.loadCurrentClasses(), this.loadOfficeHours(), this.loadPastCourses(), this.loadTerms()]).then(axios.spread(function (current_classes, office_hours, past_courses, terms) {
+        axios.all([this.loadCurrentClasses(), this.loadOfficeHours(), this.loadPastCourses(), this.loadTerms(), this.loadTeachingInterests()]).then(axios.spread(function (current_classes, office_hours, past_courses, terms, teaching_interests) {
             // apply the current classes
             var current_class_data = current_classes.data;
             _this2.classes = current_class_data;
@@ -29426,6 +29463,10 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
             var term_data = terms.data;
             _this2.terms = term_data.terms;
             _this2.current_term = term_data.current;
+
+            // apply the set of teaching interests
+            var teaching_interests_data = teaching_interests.data.interests;
+            _this2.teaching_interest = teaching_interests_data;
 
             // we have finished loading everything
             _this2.loading_all = false;
@@ -29461,6 +29502,46 @@ var render = function() {
                       "order-last order-md-first col-md-4 pt-3 pt-md-0"
                   },
                   [
+                    _c(
+                      "div",
+                      { staticClass: "mb-3 pb-3" },
+                      [
+                        _c("h6", { staticClass: "h5 mb-3" }, [
+                          _vm._v("TEACHING INTERESTS")
+                        ]),
+                        _vm._v(" "),
+                        _vm.teaching_interest.length
+                          ? [
+                              _vm._l(_vm.teaching_interest, function(interest) {
+                                return [
+                                  _c(
+                                    "span",
+                                    {
+                                      staticClass:
+                                        "badge  badge-danger badge--profile-interests py-2 px-2 my-1 mr-1"
+                                    },
+                                    [
+                                      _vm._v(
+                                        "\n                                    " +
+                                          _vm._s(interest.title) +
+                                          "\n                                "
+                                      )
+                                    ]
+                                  )
+                                ]
+                              })
+                            ]
+                          : [
+                              _c("span", { staticClass: "empty-state-msg" }, [
+                                _vm._v(
+                                  "There are currently no teaching interests to display."
+                                )
+                              ])
+                            ]
+                      ],
+                      2
+                    ),
+                    _vm._v(" "),
                     _c(
                       "div",
                       { staticClass: "mb-3 pb-3" },
@@ -29606,9 +29687,7 @@ var render = function() {
                             ]
                       ],
                       2
-                    ),
-                    _vm._v(" "),
-                    _vm._m(3)
+                    )
                   ]
                 ),
                 _vm._v(" "),
@@ -29772,7 +29851,7 @@ var render = function() {
                                     [_vm._v("Classes")]
                                   ),
                                   _vm._v(" "),
-                                  _vm.classes.length ? [_vm._m(4)] : _vm._e()
+                                  _vm.classes.length ? [_vm._m(3)] : _vm._e()
                                 ],
                                 2
                               ),
@@ -29782,10 +29861,10 @@ var render = function() {
                                   "div",
                                   { staticClass: "classes-table" },
                                   [
-                                    _vm._m(5),
+                                    _vm._m(4),
                                     _vm._v(" "),
                                     _vm.loading_classes
-                                      ? [_vm._m(6)]
+                                      ? [_vm._m(5)]
                                       : _vm.classes.length
                                         ? _vm._l(_vm.classes, function(_class) {
                                             return _vm._l(
@@ -30110,7 +30189,7 @@ var render = function() {
                                                                 ]
                                                               : _vm._e(),
                                                             _vm._v(" "),
-                                                            _vm._m(7, true)
+                                                            _vm._m(6, true)
                                                           ],
                                                           2
                                                         )
@@ -30150,7 +30229,7 @@ var render = function() {
                                 )
                               ]),
                               _vm._v(" "),
-                              _vm.classes.length ? [_vm._m(8)] : _vm._e()
+                              _vm.classes.length ? [_vm._m(7)] : _vm._e()
                             ],
                             2
                           )
@@ -30181,7 +30260,7 @@ var render = function() {
                                 [_vm._v("Office Hours")]
                               ),
                               _vm._v(" "),
-                              _vm.office_hours.length ? [_vm._m(9)] : _vm._e()
+                              _vm.office_hours.length ? [_vm._m(8)] : _vm._e()
                             ],
                             2
                           ),
@@ -30191,10 +30270,10 @@ var render = function() {
                               "div",
                               { staticClass: "classes-table" },
                               [
-                                _vm._m(10),
+                                _vm._m(9),
                                 _vm._v(" "),
                                 _vm.loading_officehours
-                                  ? [_vm._m(11)]
+                                  ? [_vm._m(10)]
                                   : _vm.office_hours.length
                                     ? _vm._l(_vm.office_hours, function(
                                         _office_hour,
@@ -30401,7 +30480,7 @@ var render = function() {
                                               2
                                             ),
                                             _vm._v(" "),
-                                            _vm._m(12, true)
+                                            _vm._m(11, true)
                                           ]
                                         )
                                       })
@@ -30432,7 +30511,7 @@ var render = function() {
                             )
                           ]),
                           _vm._v(" "),
-                          _vm.office_hours.length ? [_vm._m(13)] : _vm._e()
+                          _vm.office_hours.length ? [_vm._m(12)] : _vm._e()
                         ]
                       : _vm._e()
                   ],
@@ -30483,32 +30562,6 @@ var staticRenderFns = [
         _vm._v(" Show Fewer Courses ")
       ]
     )
-  },
-  function() {
-    var _vm = this
-    var _h = _vm.$createElement
-    var _c = _vm._self._c || _h
-    return _c("div", { staticClass: "mb-3 pb-3" }, [
-      _c("h6", { staticClass: "h5 mb-3" }, [_vm._v("TEACHING INTERESTS")]),
-      _vm._v(" "),
-      _c(
-        "span",
-        {
-          staticClass:
-            "badge  badge-danger badge--profile-interests py-2 px-2 my-1 mr-1"
-        },
-        [_vm._v("\n                            Foo\n                        ")]
-      ),
-      _vm._v(" "),
-      _c(
-        "span",
-        {
-          staticClass:
-            "badge  badge-danger badge--profile-interests py-2 px-2 my-1 mr-1"
-        },
-        [_vm._v("\n                            Bar\n                        ")]
-      )
-    ])
   },
   function() {
     var _vm = this
@@ -30753,6 +30806,9 @@ module.exports = Component.exports
 
 "use strict";
 Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+//
+//
+//
 //
 //
 //
@@ -31359,6 +31415,48 @@ var render = function() {
                   [
                     _c(
                       "div",
+                      { staticClass: "d-none d-md-block mb-3 pb-3" },
+                      [
+                        _c("h6", { staticClass: "h5 mb-3" }, [
+                          _vm._v("RESEARCH INTERESTS")
+                        ]),
+                        _vm._v(" "),
+                        _vm.interests.length
+                          ? _vm._l(_vm.interests, function(_interest) {
+                              return _c(
+                                "a",
+                                {
+                                  staticClass:
+                                    "badge  badge-danger badge--profile-interests py-2 px-2 my-1 mr-1",
+                                  attrs: {
+                                    href: _vm.generateInterestSearchUrl(
+                                      _interest
+                                    ),
+                                    target: "_blank"
+                                  }
+                                },
+                                [
+                                  _vm._v(
+                                    "\n                                " +
+                                      _vm._s(_interest.title) +
+                                      "\n                            "
+                                  )
+                                ]
+                              )
+                            })
+                          : [
+                              _c("span", { staticClass: "empty-state-msg" }, [
+                                _vm._v(
+                                  "There are currently no research interests to display."
+                                )
+                              ])
+                            ]
+                      ],
+                      2
+                    ),
+                    _vm._v(" "),
+                    _c(
+                      "div",
                       {
                         staticClass: "clearfix",
                         class: {
@@ -31620,52 +31718,7 @@ var render = function() {
                             ]
                           )
                         ]
-                      : _vm._e(),
-                    _vm._v(" "),
-                    _c(
-                      "div",
-                      { staticClass: "d-none d-md-block" },
-                      [
-                        _c(
-                          "h6",
-                          {
-                            staticClass: "h5 mb-4",
-                            class: { "mt-5": _vm.projects.length }
-                          },
-                          [_vm._v("RESEARCH INTERESTS")]
-                        ),
-                        _vm._v(" "),
-                        _vm.interests.length
-                          ? _vm._l(_vm.interests, function(_interest) {
-                              return _c(
-                                "a",
-                                {
-                                  staticClass:
-                                    "badge  badge-danger badge--profile-interests py-2 px-2 my-1 mr-1",
-                                  attrs: {
-                                    href: _vm.generateInterestSearchUrl(
-                                      _interest
-                                    ),
-                                    target: "_blank"
-                                  }
-                                },
-                                [
-                                  _vm._v(
-                                    "\n                                " +
-                                      _vm._s(_interest.title) +
-                                      "\n                            "
-                                  )
-                                ]
-                              )
-                            })
-                          : [
-                              _vm._v(
-                                "\n                            There are currently no research interests to display.\n                        "
-                              )
-                            ]
-                      ],
-                      2
-                    )
+                      : _vm._e()
                   ],
                   2
                 ),
@@ -32048,9 +32101,11 @@ var render = function() {
                               )
                             })
                           : [
-                              _vm._v(
-                                "\n                            There are currently no research interests to display.\n                        "
-                              )
+                              _c("span", { staticClass: "empty-state-msg" }, [
+                                _vm._v(
+                                  "There are currently no research interests to display."
+                                )
+                              ])
                             ]
                       ],
                       2

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -28298,7 +28298,12 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
             // apply the profile metadata
             var person_data = metadata.data;
             _this.user = person_data;
-            _this.contact = person_data.primary_connection.pivot;
+            if (person_data.primary_connection) {
+                _this.contact = person_data.primary_connection.pivot;
+            } else {
+                _this.contact = null;
+            }
+
             _this.degrees = person_data.degrees;
             _this.biography = person_data.biography;
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -28300,8 +28300,6 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
             _this.user = person_data;
             if (person_data.primary_connection) {
                 _this.contact = person_data.primary_connection.pivot;
-            } else {
-                _this.contact = null;
             }
 
             _this.degrees = person_data.degrees;

--- a/public/js/vendor.js
+++ b/public/js/vendor.js
@@ -42762,7 +42762,7 @@ module.exports = __webpack_require__(0);
 /***/ (function(module, exports) {
 
 /*!
- * Font Awesome Free 5.4.1 by @fontawesome - https://fontawesome.com
+ * Font Awesome Free 5.4.0 by @fontawesome - https://fontawesome.com
  * License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)
  */
 (function () {
@@ -43454,7 +43454,7 @@ function makeLayersCounterAbstract(params) {
 
 var noop$2 = function noop() {};
 var p = config.measurePerformance && PERFORMANCE && PERFORMANCE.mark && PERFORMANCE.measure ? PERFORMANCE : { mark: noop$2, measure: noop$2 };
-var preamble = 'FA "5.4.1"';
+var preamble = 'FA "5.4.0"';
 
 var begin = function begin(name) {
   p.mark(preamble + ' ' + name + ' begins');

--- a/resources/assets/js/components/ProfileClasses.vue
+++ b/resources/assets/js/components/ProfileClasses.vue
@@ -14,6 +14,20 @@
                 <div class="row">    
                     <div class="order-last order-md-first col-md-4 pt-3 pt-md-0">
                         <div class="mb-3 pb-3">
+                            <h6 class="h5 mb-3">TEACHING INTERESTS</h6>
+                            <template v-if="teaching_interest.length">
+                                <template v-for="interest in teaching_interest">
+                                    <span class="badge  badge-danger badge--profile-interests py-2 px-2 my-1 mr-1">
+                                        {{interest.title}}
+                                    </span>                                
+                                </template>
+                            </template>
+                            <template v-else>
+                                <span class="empty-state-msg">There are currently no teaching interests to display.</span>
+                            </template>
+                        </div>
+
+                        <div class="mb-3 pb-3">
                             <h6 class="h5 mb-3">PAST COURSES</h6>
                             <template v-if='past_courses.length'>  
                                 <ul class="past-courses-list list-unstyled">
@@ -54,15 +68,6 @@
                             <template v-else>
                                 {{ person_name }} does not have any past classes.
                             </template>
-                        </div>
-                        <div class="mb-3 pb-3">
-                            <h6 class="h5 mb-3">TEACHING INTERESTS</h6>
-                            <span class="badge  badge-danger badge--profile-interests py-2 px-2 my-1 mr-1">
-                                Foo
-                            </span>
-                            <span class="badge  badge-danger badge--profile-interests py-2 px-2 my-1 mr-1">
-                                Bar
-                            </span>
                         </div>
                     </div>
                     
@@ -312,6 +317,7 @@ export default {
             selected_term: $("meta[name=current-term-id]").attr('content'),
             classes: [],
             office_hours: [],
+            teaching_interest: [],
             loading_all: true,
             loading_classes: false,
             loading_officehours: false
@@ -335,6 +341,9 @@ export default {
         },
         current_term_id: function() {
             return $("meta[name=current-term-id]").attr('content');
+        },
+        person_email: function() {
+            return $("meta[name=person-email]").attr('content');
         }
     },
     methods: {
@@ -384,6 +393,17 @@ export default {
                 }
             );
         },
+        loadTeachingInterests: function() {
+            return axios.get(
+                'interests/academic?email=' + this.person_email,
+                {
+                    baseURL: $("meta[name=affinity-url]").attr('content'),
+                    params: {
+                        email: this.person_email
+                    }
+                }
+            );
+        },
         loadOfficeHours: function() {
             return axios.get(
                 'people/' + this.person_uri + '/office-hours',
@@ -415,8 +435,8 @@ export default {
     mounted() {
         // make the Axios calls concurrently and wait for all of them to return
         // before applying the reactive data
-        axios.all([this.loadCurrentClasses(), this.loadOfficeHours(), this.loadPastCourses(), this.loadTerms()])
-            .then(axios.spread((current_classes, office_hours, past_courses, terms) => {
+        axios.all([this.loadCurrentClasses(), this.loadOfficeHours(), this.loadPastCourses(), this.loadTerms(), this.loadTeachingInterests()])
+            .then(axios.spread((current_classes, office_hours, past_courses, terms, teaching_interests) => {
                 // apply the current classes
                 var current_class_data = current_classes.data;
                 this.classes = current_class_data;
@@ -433,6 +453,10 @@ export default {
                 var term_data = terms.data;
                 this.terms = term_data.terms;
                 this.current_term = term_data.current;
+
+                // apply the set of teaching interests
+                var teaching_interests_data = teaching_interests.data.interests;
+                this.teaching_interest = teaching_interests_data;
 
                 // we have finished loading everything
                 this.loading_all = false;

--- a/resources/assets/js/components/ProfileHome.vue
+++ b/resources/assets/js/components/ProfileHome.vue
@@ -269,7 +269,12 @@ export default {
             // apply the profile metadata
             var person_data = metadata.data;
             this.user = person_data;
-            this.contact = person_data.primary_connection.pivot;
+            if (person_data.primary_connection) {
+                this.contact = person_data.primary_connection.pivot;
+            } else {
+                this.contact = null;
+            }
+            
             this.degrees = person_data.degrees;
             this.biography = person_data.biography;
 

--- a/resources/assets/js/components/ProfileHome.vue
+++ b/resources/assets/js/components/ProfileHome.vue
@@ -271,11 +271,7 @@ export default {
             this.user = person_data;
             if (person_data.primary_connection) {
                 this.contact = person_data.primary_connection.pivot;
-            }
-                this.contact = person_data.primary_connection.pivot;
-            } else {
-                this.contact = null;
-            }
+            } 
             
             this.degrees = person_data.degrees;
             this.biography = person_data.biography;

--- a/resources/assets/js/components/ProfileHome.vue
+++ b/resources/assets/js/components/ProfileHome.vue
@@ -271,6 +271,8 @@ export default {
             this.user = person_data;
             if (person_data.primary_connection) {
                 this.contact = person_data.primary_connection.pivot;
+            }
+                this.contact = person_data.primary_connection.pivot;
             } else {
                 this.contact = null;
             }

--- a/resources/assets/js/components/ProfileHome.vue
+++ b/resources/assets/js/components/ProfileHome.vue
@@ -76,16 +76,20 @@
                             </div>
                         </template>
 
-                        <template v-if='interests.length'>
-                            <div class="mb-3 pb-3 ">
-                                <h6 class="h5 mb-3">INTERESTS</h6>
+                        
+                        <div class="mb-3 pb-3 ">
+                            <h6 class="h5 mb-3">INTERESTS</h6>
+                            <template v-if='interests.length'>
                                 <template v-for='_interest in interests'>
                                     <span class="badge badge-danger badge--profile-interests py-2 px-2 my-1 mr-1">
                                         {{ _interest.title }}
                                     </span>
                                 </template>
-                            </div>
-                        </template>
+                            </template>
+                            <template v-else>
+                                <span class="empty-state-msg">There are currently no interests to display.</span>
+                            </template>
+                        </div>
                     </div>
 
                     <div class="col-md-8 order-first order-md-last">
@@ -139,13 +143,19 @@
                             </div>
                         </template>
                         
-                        <template v-if='biography'>
-                            <h2 class="h3 d-none d-md-block text-primary">Overview</h2>
-                            <h2 class="h5 mb-3 d-block d-md-none text-uppercase">Overview</h2>
-                            <div class="mb-3 pb-3 mb-md-5 pb-md-4">
+                        
+                        <h2 class="h3 d-none d-md-block text-primary">Overview</h2>
+                        <h2 class="h5 mb-3 d-block d-md-none text-uppercase">Overview</h2>
+                    
+                        <div class="mb-3 pb-3 mb-md-5 pb-md-4">
+                            <template v-if='biography'>
                                 {{ biography }}
-                            </div>
-                        </template>
+                            </template>
+                            <template v-else>
+                                <span class="empty-state-msg">There is currently no overview information to display.</span>
+                            </template>
+                        </div>
+                        
 
                         <template v-if='badges.length'>
                             <h2 class="h3 d-none d-md-block text-primary">Badges &amp; Awards</h2>

--- a/resources/assets/js/components/ProfileProjects.vue
+++ b/resources/assets/js/components/ProfileProjects.vue
@@ -14,6 +14,19 @@
                 <div class="row">                 
                     <div class="col-md-4">
                         
+                        <div class="d-none d-md-block mb-3 pb-3">
+                            <h6 class="h5 mb-3">RESEARCH INTERESTS</h6>
+                            <template v-if="interests.length">
+                                <a :href="generateInterestSearchUrl(_interest)" v-for="_interest in interests" class="badge  badge-danger badge--profile-interests py-2 px-2 my-1 mr-1" target="_blank">
+                                    {{ _interest.title }}
+                                </a>
+                            </template>
+                            <template v-else>
+                                <span class="empty-state-msg">There are currently no research interests to display.</span>
+                            </template>
+                        </div>
+                        
+
                         <div class="clearfix" v-bind:class="{ 'd-block': isMobile, 'd-none': isDesktop }">
                             <h2 class="h3 text-primary mb-4 float-left">Projects</h2>
                             <div v-if="projects.length" class="btn btn-sm btn-secondary float-right" data-toggle="collapse" data-target="#collapseFilters" aria-expanded="false" aria-controls="collapseFilters"> 
@@ -85,17 +98,7 @@
                             </div>
                         </template>
 
-                        <div class="d-none d-md-block">
-                            <h6 class="h5 mb-4" v-bind:class="{'mt-5': projects.length}">RESEARCH INTERESTS</h6>
-                            <template v-if="interests.length">
-                                <a :href="generateInterestSearchUrl(_interest)" v-for="_interest in interests" class="badge  badge-danger badge--profile-interests py-2 px-2 my-1 mr-1" target="_blank">
-                                    {{ _interest.title }}
-                                </a>
-                            </template>
-                            <template v-else>
-                                There are currently no research interests to display.
-                            </template>
-                        </div>
+
                     </div>
 
                     <div class="col-md-8">
@@ -185,7 +188,7 @@
                                 </a>
                             </template>
                             <template v-else>
-                                There are currently no research interests to display.
+                                <span class="empty-state-msg">There are currently no research interests to display.</span>
                             </template>
                         </div>
 

--- a/resources/assets/sass/_globals.scss
+++ b/resources/assets/sass/_globals.scss
@@ -6,3 +6,7 @@ body {
 .main {
     min-height: calc(100vh - 30rem);
 }
+
+.empty-state-msg {
+    color: $gray-600;
+}


### PR DESCRIPTION
This branch accomplishes a couple of things:

(1) Make "teaching interests" section on "classes" tab dynamic. (Instead of just displaying "foo bar")
(2) Bring "teaching interests" and "research interests"sections (1 on each tab) to the TOP of the sidebar instead of the BOTTOM, per Steve's request
(3) Unify the way each of those 3 "interests" sections handles empty state
(4) Makes the "overview" section handle empty state in the same way as the "interests" sections (display a message instead of just hiding the section entirely, per Steve's request)
(5) fixes a bug that Luis found on ProfileHome.vue (do existence check before pivot)